### PR TITLE
Allow custom directory for image saving

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7,8 +7,7 @@ import time
 
 from flask import Flask, request, jsonify
 from flask_cors import CORS, cross_origin
-from consts import IMAGES_OUTPUT_DIR
-from utils import parse_arg_boolean, parse_arg_dalle_version
+from utils import parse_arg_boolean, parse_arg_dalle_version, parse_arg_save_dir
 from consts import ModelSize
 
 app = Flask(__name__)
@@ -22,6 +21,8 @@ parser = argparse.ArgumentParser(description = "A DALL-E app to turn your textua
 parser.add_argument("--port", type=int, default=8000, help = "backend port")
 parser.add_argument("--model_version", type = parse_arg_dalle_version, default = ModelSize.MINI, help = "Mini, Mega, or Mega_full")
 parser.add_argument("--save_to_disk", type = parse_arg_boolean, default = False, help = "Should save generated images to disk")
+parser.add_argument("--save_dir", type = parse_arg_save_dir, default = "generations", help = "Custom directory for saved images")
+
 args = parser.parse_args()
 
 @app.route("/dalle", methods=["POST"])
@@ -34,7 +35,7 @@ def generate_images_api():
 
     generated_images = []
     if args.save_to_disk: 
-        dir_name = os.path.join(IMAGES_OUTPUT_DIR,f"{time.strftime('%Y-%m-%d_%H:%M:%S')}_{text_prompt}")
+        dir_name = os.path.join(args.save_dir,f"{time.strftime('%Y-%m-%d_%H:%M:%S')}_{text_prompt}")
         Path(dir_name).mkdir(parents=True, exist_ok=True)
     
     for idx, img in enumerate(generated_imgs):

--- a/backend/consts.py
+++ b/backend/consts.py
@@ -1,7 +1,5 @@
 from enum import Enum 
 
-IMAGES_OUTPUT_DIR = 'generations'
-
 DALLE_MODEL_MINI = "dalle-mini/dalle-mini/mini-1:v0"  # the original DALL-E Mini. Fastest yet suboptimal results
 DALLE_MODEL_MEGA = "dalle-mini/dalle-mini/mega-1-fp16:latest"  # the advanced version of DALL-E Mini. Requires more compute and VRAM
 DALLE_MODEL_MEGA_FULL = "dalle-mini/dalle-mini/mega-1:latest"  # DALL-E Mega. Warning: requires significantly more storage and GPU RAM

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -14,3 +14,6 @@ def parse_arg_boolean(value):
 def parse_arg_dalle_version(value):
     value = value.lower()
     return ModelSize[value.upper()]
+
+def parse_arg_save_dir(value):
+	return value


### PR DESCRIPTION
Adds --save_dir option.  If not specified, images will continue to be saved in the "generations" subdirectory as currently done.  If specified, images will be saved in whatever directory was specified.