### PR TITLE
Prompts from File/Notification Bell

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ BASH-E takes the following arguments:
 
 --ascii (draw ascii art as images are generated). True/False.  Default False.  Does not work in Colab, or versions of Python less than 3.8.
 
+--list (filename).  Generates based on prompts stored in file, format should be "prompt, number of images" with one prompt per line.
+
 ## Which Model do I use?
 
 Currently there are three models to choose from:

--- a/backend/BASH-E.py
+++ b/backend/BASH-E.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import time
 
-from utils import parse_arg_dalle_version, parse_arg_save_dir, parse_arg_format, parse_arg_prompt, parse_arg_boolean
+from utils import parse_arg_dalle_version, parse_arg_save_dir, parse_arg_format, parse_arg_prompt, parse_arg_boolean, parse_arg_list
 from consts import ModelSize
 
 print("--> Starting BASH-E.  This may take several minutes, depending on model size.")
@@ -19,6 +19,7 @@ parser.add_argument("--interactive", type = parse_arg_boolean, default = False, 
 parser.add_argument("--num", type = int, default = 10, help = "Number of images to generate.  Default 10")
 parser.add_argument("--prompt", type = parse_arg_prompt, default = "A quick brown fox jumping over a lazy dog", help = "Text Prompt to use")
 parser.add_argument("--ascii", type = parse_arg_boolean, default = False, help = "Draw ASCII art of generated images as they're generated.")
+parser.add_argument("--list", type = parse_arg_list, default ="", help = "List of prompts to run.  Ignores --num and --prompt.")
 args = parser.parse_args()
 
 if (args.ascii):
@@ -31,7 +32,7 @@ print(f"DALL-E model {args.model_version} loading...")
 dalle_model = DalleModel(args.model_version)
 
 print("Model loaded.")
-	
+
 def generate(prompt: str, num: int):
 
 	print(f"Now generating {num} images from prompt [{prompt}].")
@@ -43,22 +44,30 @@ def generate(prompt: str, num: int):
 	#This could be done without a loop like this - generate_images can be called directly.  However, doing it this way means that it will save each and every image immediately after it's generated; rather than generating all the images and then saving them.
 
 	for idx in range(num):
-	
+
 		generated_img=dalle_model.generate_images(prompt, 1)
 		for img in generated_img:
 			img.save(os.path.join(dir_name, f'{idx}.{args.format}'), format=args.format)
 			if (args.ascii):
 				convert(img)
-				
+
 			print(f"Saved {idx}.{args.format}...")
-			
+
 
 	print(f"Created {num} images from text prompt [{prompt}]")
-	
+
 while (args.interactive):
 	print("Running in interactive mode.  Ctrl+C to quit...")
 	prompt = input("Text prompt? ")
 	num = int(input("Number of images? "))
 	generate(prompt, num)
 else:
-	generate(args.prompt, args.num)
+	if args.list != "":
+
+		for idx, string in enumerate(args.list):
+			data = string.split(", ", 1)
+			prompt = data[0]
+			num = int(data[1])
+			generate (prompt, num)
+	else:
+		generate(args.prompt, args.num)

--- a/backend/BASH-E.py
+++ b/backend/BASH-E.py
@@ -54,7 +54,7 @@ def generate(prompt: str, num: int):
 			print(f"Saved {idx}.{args.format}...")
 
 
-	print(f"Created {num} images from text prompt [{prompt}]")
+	print(f"Created {num} images from text prompt [{prompt}]\a")
 
 while (args.interactive):
 	print("Running in interactive mode.  Ctrl+C to quit...")

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -26,3 +26,12 @@ def parse_arg_save_dir(value):
 
 def parse_arg_prompt(value):
 	return value
+
+def parse_arg_list(value):
+	if value == "":
+		return ""
+	else:
+		listfile = open(value, "r")
+		value = listfile.read()
+		value = value.splitlines()
+		return value


### PR DESCRIPTION
Add a --file argument.  This argument takes a filename and is by default blank.

The file should contain lines in the format of "Prompt", "Number of Images to create"; for each prompt BASH-E will generate it, save it to its own folder, and then exit once all prompts are exhausted.

Also a minor change; once a prompt is completed - whether in interactive mode, from a file, etc, a terminal bell will sound.